### PR TITLE
Add table pagination

### DIFF
--- a/main.js
+++ b/main.js
@@ -7,10 +7,12 @@ const URL = isDev
   ? 'http://localhost:5173'
   : `file://${path.join(__dirname, 'dist/index.html')}`
 
+const pythonCmd = process.platform === 'win32' ? 'python' : 'python3'
+
 
 ipcMain.handle('run-python', () => {
   return new Promise((resolve, reject) => {
-    execFile('python3', [path.join(__dirname, 'script.py')], (error, stdout, stderr) => {
+    execFile(pythonCmd, [path.join(__dirname, 'script.py')], (error, stdout, stderr) => {
       if (error) {
         console.error(stderr)
         reject(stderr)

--- a/script.py
+++ b/script.py
@@ -36,7 +36,7 @@ try:
         cursor.execute("{CALL sp_traer_clientes}")
         columns = [c[0] for c in cursor.description]
         rows = [dict(zip(columns, row)) for row in cursor.fetchall()]
-        print(json.dumps({'columns': columns, 'rows': rows}))
+        print(json.dumps({'columns': columns, 'rows': rows}, default=str))
 except Exception as e:
     print("Connection failed:")
     print(e)

--- a/src/App.css
+++ b/src/App.css
@@ -89,3 +89,15 @@ thead th {
   overflow-x: hidden;
   padding-left: 20px;
 }
+
+.pagination {
+  margin-top: 10px;
+  display: flex;
+  gap: 10px;
+  justify-content: center;
+}
+
+.pagination button {
+  padding: 5px 10px;
+  cursor: pointer;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,19 @@
-import React, {useState} from 'react'
+import React, { useState } from 'react'
 import './App.css'
 
 export default function App() {
   const [columns, setColumns] = useState<string[]>([])
   const [rows, setRows] = useState<any[]>([])
+  const [currentPage, setCurrentPage] = useState(0)
   const [button2Text, setButton2Text] = useState('Opcion 2')
+
+  const ITEMS_PER_PAGE = 100
+
+  const totalPages = Math.ceil(rows.length / ITEMS_PER_PAGE)
+  const displayRows = rows.slice(
+    currentPage * ITEMS_PER_PAGE,
+    (currentPage + 1) * ITEMS_PER_PAGE
+  )
 
   const handleButton1Click = async () => {
     try {
@@ -15,6 +24,7 @@ export default function App() {
           if (Array.isArray(data.columns) && Array.isArray(data.rows)) {
             setColumns(data.columns)
             setRows(data.rows)
+            setCurrentPage(0)
           }
         } catch (e) {
           console.error('Failed to parse python output', e)
@@ -48,7 +58,7 @@ export default function App() {
             </tr>
           </thead>
           <tbody>
-            {rows.map((row, i) => (
+            {displayRows.map((row, i) => (
               <tr key={i}>
                 {columns.map(col => (
                   <td key={col}>{row[col]}</td>
@@ -57,6 +67,15 @@ export default function App() {
             ))}
           </tbody>
         </table>
+        <div className="pagination">
+          <button onClick={() => setCurrentPage(p => Math.max(0, p - 1))} disabled={currentPage === 0}>
+            ←
+          </button>
+          <span>{currentPage + 1} / {totalPages || 1}</span>
+          <button onClick={() => setCurrentPage(p => Math.min(totalPages - 1, p + 1))} disabled={currentPage >= totalPages - 1}>
+            →
+          </button>
+        </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- paginate table results 100 at a time with arrow buttons

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68780600da408332afa4b804a4974477