### PR TITLE
Update styles and pagination

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,13 +1,6 @@
-@font-face {
-  font-family: 'Fitgree';
-  src: url('/fonts/fitgree.ttf') format('truetype');
-  font-weight: normal;
-  font-style: normal;
-}
-
 body {
   margin: 0;
-  font-family: 'Fitgree', Arial, "Helvetica Neue", Helvetica, sans-serif;
+  font-family: 'Figtree', Arial, "Helvetica Neue", Helvetica, sans-serif;
 }
 
 .app {
@@ -46,7 +39,7 @@ body {
   display: flex;
   flex-direction: column;
   gap: 10px;
-  margin-right: 20px;
+  margin-right: 0;
   border-right: 1px solid #ccc;
   padding-right: 20px;
 }
@@ -87,7 +80,7 @@ thead th {
   flex: 1;
   overflow-y: auto;
   overflow-x: hidden;
-  padding-left: 20px;
+  padding-left: 0;
 }
 
 .pagination {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,7 @@ export default function App() {
   const [rows, setRows] = useState<any[]>([])
   const [currentPage, setCurrentPage] = useState(0)
 
-  const ITEMS_PER_PAGE = 100
+  const ITEMS_PER_PAGE = 25
 
   const totalPages = Math.ceil(rows.length / ITEMS_PER_PAGE)
   const displayRows = rows.slice(

--- a/src/index.html
+++ b/src/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <title>Naviera App</title>
+  <link href="https://fonts.googleapis.com/css2?family=Figtree&display=swap" rel="stylesheet" />
 </head>
 <body>
   <div id="root"></div>


### PR DESCRIPTION
## Summary
- use Google's Figtree font
- shrink page size to 25 rows
- remove spacing around sidebar/table divider

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687811934a8c83328b99125a2bcd10f8