### PR TITLE
Add row selection and data display

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -113,3 +113,13 @@ thead th {
   padding: 5px 10px;
   cursor: pointer;
 }
+
+tr.selected {
+  background-color: #bde5ff;
+}
+
+.sidebar input {
+  padding: 5px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,8 @@ export default function App() {
   const [rows, setRows] = useState<any[]>([])
   const [currentPage, setCurrentPage] = useState(0)
   const [columnWidths, setColumnWidths] = useState<number[]>([])
+  const [selectedRowIndex, setSelectedRowIndex] = useState<number | null>(null)
+  const [selectedRow, setSelectedRow] = useState<any | null>(null)
 
   const ITEMS_PER_PAGE = 25
 
@@ -77,6 +79,30 @@ export default function App() {
           <button>Opcion 2</button>
           <button>Opcion 3</button>
           <button>Opcion 4</button>
+          <input
+            type="text"
+            value={selectedRow ? selectedRow[columns[0]] || '' : ''}
+            placeholder={columns[0] || 'Campo 1'}
+            readOnly
+          />
+          <input
+            type="text"
+            value={selectedRow ? selectedRow[columns[1]] || '' : ''}
+            placeholder={columns[1] || 'Campo 2'}
+            readOnly
+          />
+          <input
+            type="text"
+            value={selectedRow ? selectedRow[columns[2]] || '' : ''}
+            placeholder={columns[2] || 'Campo 3'}
+            readOnly
+          />
+          <input
+            type="text"
+            value={selectedRow ? selectedRow[columns[3]] || '' : ''}
+            placeholder={columns[3] || 'Campo 4'}
+            readOnly
+          />
         </div>
         <div className="table-container">
         <table>
@@ -92,7 +118,14 @@ export default function App() {
           </thead>
           <tbody>
             {displayRows.map((row, i) => (
-              <tr key={i}>
+              <tr
+                key={i}
+                className={selectedRowIndex === i ? 'selected' : ''}
+                onClick={() => {
+                  setSelectedRowIndex(i)
+                  setSelectedRow(row)
+                }}
+              >
                 {columns.map((col, idx) => (
                   <td key={col} style={{ width: columnWidths[idx] }}>
                     {row[col]}


### PR DESCRIPTION
## Summary
- show 4 readonly entry boxes under sidebar buttons
- allow selecting table rows and highlight the selection
- display selected row data in the entry boxes

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687826ece9488332966b415f41b65d84