### PR TITLE
Update runPython signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,14 @@ The Electron window will load the Vite development server.
 connections alive. Electron launches this process when the application
 starts and communicates with it through standard input/output.
 
-To fetch clients from the app you can invoke:
+To run Python commands from the renderer you can call:
+
+```ts
+window.electronAPI.runPython(cmd, params?)
+```
+
+Where `cmd` is the command string (for example `'get_clientes'`) and `params` is
+an optional array of arguments. A simple call fetching clients would look like:
 
 ```ts
 window.electronAPI.runPython('get_clientes')

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,5 +1,5 @@
 export interface ElectronAPI {
-  runPython: () => Promise<string>
+  runPython: (cmd: string, params?: any[]) => Promise<string>
 }
 
 declare global {


### PR DESCRIPTION
## Summary
- type `runPython` with cmd string and optional params array
- document new param usage in the README

## Testing
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_687831623b5c8332936c14236fcb0fee