### PR TITLE
Implement second table loader

### DIFF
--- a/script.py
+++ b/script.py
@@ -88,6 +88,28 @@ def update_cliente(pool: ConnectionPool, cod_cliente, new_razon_social, new_dom_
     )
 
 
+def run_procedure(pool: ConnectionPool, call: str, params=()) -> dict:
+    """Execute a procedure that does not return a result set."""
+    conn = get_connection(pool)
+    try:
+        cursor = conn.cursor()
+        cursor.execute(call, params)
+        conn.commit()
+        return {"status": "ok"}
+    finally:
+        pool.release(conn)
+
+
+def modificar_cobros_impagos(pool: ConnectionPool):
+    """Execute the `modificar_cobros_impagos` procedure."""
+    return run_procedure(pool, '{CALL modificar_cobros_impagos}')
+
+
+def traer_incongruencias(pool: ConnectionPool):
+    """Return the result of the `traer_incongruencias` procedure."""
+    return execute_procedure(pool, '{CALL traer_incongruencias}')
+
+
 def main() -> None:
     """Run a small command loop reading JSON from stdin."""
     pool = ConnectionPool()
@@ -115,6 +137,10 @@ def main() -> None:
             res = get_clientes(pool)
         elif cmd == "update_cliente":
             res = update_cliente(pool, *params)
+        elif cmd == "modificar_cobros_impagos":
+            res = modificar_cobros_impagos(pool)
+        elif cmd == "traer_incongruencias":
+            res = traer_incongruencias(pool)
         elif cmd == "exit":
             break
         else:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -52,6 +52,38 @@ export default function App() {
       console.error('runPython failed', err)
     }
   }
+
+  const handleButton2Click = async () => {
+    try {
+      if (window.electronAPI?.runPython) {
+        await window.electronAPI.runPython('modificar_cobros_impagos')
+        const result = await window.electronAPI.runPython('traer_incongruencias')
+        try {
+          const data = JSON.parse(result)
+          if (Array.isArray(data.columns) && Array.isArray(data.rows)) {
+            const newColumns = data.columns
+            const newRows = data.rows.map((row: any) => {
+              const r: Record<string, any> = {}
+              newColumns.forEach((c: string) => {
+                r[c] = row[c]
+              })
+              return r
+            })
+            setColumns(newColumns)
+            setRows(newRows)
+            setCurrentPage(0)
+            setColumnWidths(newColumns.map(() => 150))
+            setSelectedRowIndex(null)
+            setSelectedRow(null)
+          }
+        } catch (e) {
+          console.error('Failed to parse python output', e)
+        }
+      }
+    } catch (err) {
+      console.error('runPython failed', err)
+    }
+  }
   const handleMouseDown = (e: React.MouseEvent, index: number) => {
     const startX = e.clientX;
     const startWidth = columnWidths[index];
@@ -76,7 +108,7 @@ export default function App() {
       <div className="content">
         <div className="sidebar">
           <button onClick={handleButton1Click}>Traer Clientes</button>
-          <button>Opcion 2</button>
+          <button onClick={handleButton2Click}>Opcion 2</button>
           <button>Opcion 3</button>
           <button>Opcion 4</button>
           <input


### PR DESCRIPTION
## Summary
- add DB helpers for `modificar_cobros_impagos` and `traer_incongruencias`
- expose new commands in script.py command loop
- call both commands from new button action in React app
- replace second sidebar button with implementation

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6878fc01a4148332b31b7a5cdc58c1e2