### PR TITLE
Handle SQL rowcounts in procedure calls

### DIFF
--- a/main.js
+++ b/main.js
@@ -32,9 +32,13 @@ ipcMain.handle('run-python', (_event, cmd, params = []) => {
   if (!pythonProc) return Promise.reject(new Error('python not running'))
   const message = JSON.stringify({ cmd, params }) + '\n'
   return new Promise((resolve, reject) => {
+    let buffer = ''
     const onData = (data) => {
-      cleanup()
-      resolve(data.toString())
+      buffer += data.toString()
+      if (buffer.includes('\n')) {
+        cleanup()
+        resolve(buffer.trim())
+      }
     }
     const onErr = (err) => {
       cleanup()
@@ -44,7 +48,7 @@ ipcMain.handle('run-python', (_event, cmd, params = []) => {
       pythonProc.stdout.off('data', onData)
       pythonProc.stderr.off('data', onErr)
     }
-    pythonProc.stdout.once('data', onData)
+    pythonProc.stdout.on('data', onData)
     pythonProc.stderr.once('data', onErr)
     pythonProc.stdin.write(message)
   })

--- a/script.py
+++ b/script.py
@@ -67,6 +67,17 @@ def execute_procedure(pool: ConnectionPool, call: str, params=()):
     try:
         cursor = conn.cursor()
         cursor.execute(call, params)
+
+        # Some procedures may emit rowcount messages before returning a result
+        # set. Advance through result sets until one with column metadata is
+        # available or no more sets remain.
+        while cursor.description is None and cursor.nextset():
+            pass
+
+        if cursor.description is None:
+            # Procedure returned no result set
+            return {"columns": [], "rows": []}
+
         columns = [c[0] for c in cursor.description]
         rows = [dict(zip(columns, row)) for row in cursor.fetchall()]
         return {"columns": columns, "rows": rows}
@@ -86,6 +97,28 @@ def update_cliente(pool: ConnectionPool, cod_cliente, new_razon_social, new_dom_
         '{CALL new_edit_cliente (?, ?, ?)}',
         (cod_cliente, new_razon_social, new_dom_fiscal1)
     )
+
+
+def run_procedure(pool: ConnectionPool, call: str, params=()) -> dict:
+    """Execute a procedure that does not return a result set."""
+    conn = get_connection(pool)
+    try:
+        cursor = conn.cursor()
+        cursor.execute(call, params)
+        conn.commit()
+        return {"status": "ok"}
+    finally:
+        pool.release(conn)
+
+
+def modificar_cobros_impagos(pool: ConnectionPool):
+    """Execute the `modificar_cobros_impagos` procedure."""
+    return run_procedure(pool, '{CALL modificar_cobros_impagos}')
+
+
+def traer_incongruencias(pool: ConnectionPool):
+    """Return the result of the `traer_incongruencias` procedure."""
+    return execute_procedure(pool, '{CALL traer_incongruencias}')
 
 
 def main() -> None:
@@ -115,6 +148,10 @@ def main() -> None:
             res = get_clientes(pool)
         elif cmd == "update_cliente":
             res = update_cliente(pool, *params)
+        elif cmd == "modificar_cobros_impagos":
+            res = modificar_cobros_impagos(pool)
+        elif cmd == "traer_incongruencias":
+            res = traer_incongruencias(pool)
         elif cmd == "exit":
             break
         else:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -52,6 +52,38 @@ export default function App() {
       console.error('runPython failed', err)
     }
   }
+
+  const handleButton2Click = async () => {
+    try {
+      if (window.electronAPI?.runPython) {
+        await window.electronAPI.runPython('modificar_cobros_impagos')
+        const result = await window.electronAPI.runPython('traer_incongruencias')
+        try {
+          const data = JSON.parse(result)
+          if (Array.isArray(data.columns) && Array.isArray(data.rows)) {
+            const newColumns = data.columns
+            const newRows = data.rows.map((row: any) => {
+              const r: Record<string, any> = {}
+              newColumns.forEach((c: string) => {
+                r[c] = row[c]
+              })
+              return r
+            })
+            setColumns(newColumns)
+            setRows(newRows)
+            setCurrentPage(0)
+            setColumnWidths(newColumns.map(() => 150))
+            setSelectedRowIndex(null)
+            setSelectedRow(null)
+          }
+        } catch (e) {
+          console.error('Failed to parse python output', e)
+        }
+      }
+    } catch (err) {
+      console.error('runPython failed', err)
+    }
+  }
   const handleMouseDown = (e: React.MouseEvent, index: number) => {
     const startX = e.clientX;
     const startWidth = columnWidths[index];
@@ -76,7 +108,7 @@ export default function App() {
       <div className="content">
         <div className="sidebar">
           <button onClick={handleButton1Click}>Traer Clientes</button>
-          <button>Opcion 2</button>
+          <button onClick={handleButton2Click}>Opcion 2</button>
           <button>Opcion 3</button>
           <button>Opcion 4</button>
           <input


### PR DESCRIPTION
## Summary
- gather Python output until newline so JSON isn't truncated
- add helper functions to run procedures from React
- skip rowcount messages in Python `execute_procedure`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6878fc01a4148332b31b7a5cdc58c1e2