### PR TITLE
Fix assets for production build

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ npm install
 npm run dev
 ```
 
+For a production build run:
+
+```bash
+npm run build
+npm start
+```
+
 The Electron window will load the Vite development server.
 
 ## Python helper script

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import './App.css'
+import logo from './assets/logopng.png'
 
 export default function App() {
   const [columns, setColumns] = useState<string[]>([])
@@ -197,7 +198,7 @@ export default function App() {
 
   return (
     <div className="app">
-      <div className="top-bar"><img src="./assets/logopng.png" alt="logo" />La Naviera</div>
+      <div className="top-bar"><img src={logo} alt="logo" />La Naviera</div>
       <div className="content">
         <div className="sidebar">
           <input className="search-input"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,7 @@ import path from 'path'
 
 export default defineConfig({
   root: 'src',
+  base: './',
   build: {
     outDir: path.resolve(__dirname, 'dist'),
     emptyOutDir: true,


### PR DESCRIPTION
## Summary
- reference the logo image via ES module import
- configure Vite to emit relative paths so assets load when `npm start`
- document how to create a production build

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68795f9f693c83329556d7be1e2422f3