### PR TITLE
Enable electron build with resources

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,13 +17,37 @@
     "start": "cross-env NODE_ENV=production electron .",
     "dist": "electron-builder"
   },
-  "build":{
+  "build": {
     "appId": "com.l34n07.navieraapp",
     "productName": "Naviera App",
-    "win":{
-      "target": "portable"
+    "directories": {
+      "buildResources": "public"
+    },
+    "files": [
+      "dist/**/*",
+      "main.js",
+      "preload.js",
+      "script.py",
+      "package.json",
+      "public/**/*",
+      "src/assets/**/*"
+    ],
+    "extraResources": [
+      {
+        "from": "public/fonts",
+        "to": "fonts",
+        "filter": ["**/*"]
+      }
+    ],
+    "win": {
+      "target": "nsis",
+      "icon": "public/logo.ico"
+    },
+    "linux": {
+      "target": "AppImage",
+      "icon": "src/assets/logopng.png"
     }
-    
+
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- configure `package.json` for electron-builder

## Testing
- `npm test` *(fails: Missing script)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68797272fa808332b52b56d4dfc3ab44