### PR TITLE
Fix path to python script when packaged

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ npm run dist
 ```
 
 Make sure the system has Python and its dependencies (like `pyodbc`)
-installed, as the packaged app spawns `script.py` at runtime.
+installed, as the packaged app spawns `script.py` at runtime. When
+packaged, `script.py` is unpacked into the `resources/app.asar.unpacked`
+directory so Electron can run it.
 
 The Electron window will load the Vite development server.
 

--- a/main.js
+++ b/main.js
@@ -14,7 +14,7 @@ let pythonProc
 function startPython() {
   const script = process.env.NODE_ENV === 'development'
     ? path.join(__dirname, 'script.py')
-    : path.join(process.resourcesPath, 'script.py')
+    : path.join(process.resourcesPath, 'app.asar.unpacked', 'script.py')
   pythonProc = spawn(pythonCmd, [script])
   pythonProc.stdout.setEncoding('utf8')
 }


### PR DESCRIPTION
## Summary
- fix startup script path in production
- document location of unpacked script in README

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687979177ddc83329c762e41eec7aa7e